### PR TITLE
Lagre hva slags type vedlegg/dokument vi har mottatt

### DIFF
--- a/src/main/kotlin/no/nav/melosys/soknadmottak/dokument/Dokument.kt
+++ b/src/main/kotlin/no/nav/melosys/soknadmottak/dokument/Dokument.kt
@@ -17,10 +17,9 @@ class Dokument(
     @Column(name = "filnavn", nullable = false)
     var filnavn: String,
 
-    @Enumerated(EnumType.STRING)
     @Column(name = "dok_type", nullable = false)
-    var type: DokumentType,
-    
+    var type: String,
+
     @Column(name = "innhold", nullable = false)
     var innhold: ByteArray,
 

--- a/src/main/kotlin/no/nav/melosys/soknadmottak/dokument/DokumentDto.kt
+++ b/src/main/kotlin/no/nav/melosys/soknadmottak/dokument/DokumentDto.kt
@@ -6,7 +6,7 @@ data class DokumentDto(
     val soknadID: String,
     val dokumentID: String,
     val tittel: String,
-    val dokumentType: DokumentType,
+    val dokumentType: String,
     val innhold: String
 ) {
     constructor(dokument: Dokument) : this(

--- a/src/main/kotlin/no/nav/melosys/soknadmottak/dokument/DokumentType.kt
+++ b/src/main/kotlin/no/nav/melosys/soknadmottak/dokument/DokumentType.kt
@@ -1,5 +1,7 @@
 package no.nav.melosys.soknadmottak.dokument
 
-enum class DokumentType {
-    SOKNAD, VEDLEGG
+class DokumentType {
+    companion object {
+        val SOKNAD = "SOKNAD"
+    }
 }

--- a/src/main/kotlin/no/nav/melosys/soknadmottak/polling/DownloadQueueService.kt
+++ b/src/main/kotlin/no/nav/melosys/soknadmottak/polling/DownloadQueueService.kt
@@ -9,8 +9,7 @@ import no.nav.melosys.soknadmottak.common.MDC_CALL_ID
 import no.nav.melosys.soknadmottak.config.MottakConfig
 import no.nav.melosys.soknadmottak.dokument.Dokument
 import no.nav.melosys.soknadmottak.dokument.DokumentService
-import no.nav.melosys.soknadmottak.dokument.DokumentType.SOKNAD
-import no.nav.melosys.soknadmottak.dokument.DokumentType.VEDLEGG
+import no.nav.melosys.soknadmottak.dokument.DokumentType
 import no.nav.melosys.soknadmottak.kafka.KafkaProducer
 import no.nav.melosys.soknadmottak.kafka.SoknadMottatt
 import no.nav.melosys.soknadmottak.polling.altinn.AltinnProperties
@@ -54,7 +53,7 @@ class DownloadQueueService(
                     )
                     if (soknadRepository.findByArkivReferanse(arkivRef).count() == 0) {
                         soknadRepository.save(søknad)
-                        dokumentService.lagreDokument(Dokument(søknad, "ref_$arkivRef.pdf", SOKNAD, hentSkjemaPdf(arkivRef)))
+                        dokumentService.lagreDokument(Dokument(søknad, "ref_$arkivRef.pdf", DokumentType.SOKNAD, hentSkjemaPdf(arkivRef)))
                         kafkaProducer.publiserMelding(SoknadMottatt(søknad))
                         behandleVedleggListe(søknad, vedlegg, arkivRef)
                         fjernElementFraKø(arkivRef)
@@ -82,7 +81,7 @@ class DownloadQueueService(
     }
 
     private fun behandleVedlegg(søknad: Soknad, attachment: ArchivedAttachmentDQBE) {
-        dokumentService.lagreDokument(Dokument(søknad, attachment.fileName, VEDLEGG, attachment.attachmentData))
+        dokumentService.lagreDokument(Dokument(søknad, attachment.fileName, attachment.attachmentTypeName, attachment.attachmentData))
     }
 
     private fun hentSkjemaPdf(arkivRef: String) =

--- a/src/test/kotlin/no/nav/melosys/soknadmottak/dokument/DokumentFactory.kt
+++ b/src/test/kotlin/no/nav/melosys/soknadmottak/dokument/DokumentFactory.kt
@@ -9,6 +9,6 @@ object DokumentFactory {
     private val ulid: ULID = ULID()
 
     fun lagDokument(soknad: Soknad = lagSoknad(), innhold: ByteArray = "pdf".toByteArray()): Dokument {
-        return Dokument(soknad, "fil_navn", DokumentType.VEDLEGG, innhold, Instant.MIN, ulid.nextULID())
+        return Dokument(soknad, "fil_navn", DokumentType.SOKNAD, innhold, Instant.MIN, ulid.nextULID())
     }
 }

--- a/src/test/kotlin/no/nav/melosys/soknadmottak/polling/service/DownloadQueueServiceTest.kt
+++ b/src/test/kotlin/no/nav/melosys/soknadmottak/polling/service/DownloadQueueServiceTest.kt
@@ -65,6 +65,7 @@ class DownloadQueueServiceTest {
         val vedlegg1 = ArchivedAttachmentDQBE().apply {
             attachmentData = ByteArray(8)
             fileName = "vedlegg_1"
+            attachmentTypeName = "Fullmakt"
         }
         val vedleggListe = ArchivedAttachmentExternalListDQBE().withArchivedAttachmentDQBE(vedlegg1)
 


### PR DESCRIPTION
Fjerner DokumentType enum, og gjør den heller til en klasse med konst…ant. Felt dok_type i tabell DOKUMENT er da blitt en String, som skal reflektere attachmentTypeName som beskriver hva slags vedlegg det da er snakk om

Dette er gjort for å enklere tilrettelegge for andre typer vedlegg vi kan motta ved en senere anledning - hvis det skulle bli aktuelt med noe annet enn Fullmakt