### PR TITLE
Legg til mer logging ved henting av søknad

### DIFF
--- a/mottak/src/main/kotlin/no/nav/melosys/soknadmottak/common/Exceptions.kt
+++ b/mottak/src/main/kotlin/no/nav/melosys/soknadmottak/common/Exceptions.kt
@@ -1,13 +1,18 @@
 package no.nav.melosys.soknadmottak.common
 
+import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus
+
+private val logger = KotlinLogging.logger { }
 
 @ResponseStatus(value = HttpStatus.NOT_FOUND)
 class IkkeFunnetException : Exception {
     constructor(melding: String, throwable: Throwable) : super(melding, throwable)
 
-    constructor(melding: String) : super(melding)
+    constructor(melding: String): super(melding) {
+        logger.error { melding }
+    }
 
     constructor(throwable: Throwable) : super(throwable)
 }

--- a/mottak/src/main/kotlin/no/nav/melosys/soknadmottak/soknad/SoknadResponseBodyAdvice.kt
+++ b/mottak/src/main/kotlin/no/nav/melosys/soknadmottak/soknad/SoknadResponseBodyAdvice.kt
@@ -11,6 +11,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
 
 private val logger = KotlinLogging.logger { }
 
+// FIXME: Denne må fjernes før vi går i prod, siden søknaden inneholder sensitive opplysninger
 @ControllerAdvice
 class SoknadResponseBodyAdvice : ResponseBodyAdvice<Any?> {
     override fun supports(returnType: MethodParameter, converterType: Class<out HttpMessageConverter<*>>): Boolean {

--- a/mottak/src/main/kotlin/no/nav/melosys/soknadmottak/soknad/SoknadResponseBodyAdvice.kt
+++ b/mottak/src/main/kotlin/no/nav/melosys/soknadmottak/soknad/SoknadResponseBodyAdvice.kt
@@ -1,0 +1,31 @@
+package no.nav.melosys.soknadmottak.soknad
+
+import mu.KotlinLogging
+import org.springframework.core.MethodParameter
+import org.springframework.http.MediaType
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
+
+private val logger = KotlinLogging.logger { }
+
+@ControllerAdvice
+class SoknadResponseBodyAdvice : ResponseBodyAdvice<Any?> {
+    override fun supports(returnType: MethodParameter, converterType: Class<out HttpMessageConverter<*>>): Boolean {
+        return (returnType.method?.name == "hentSøknad")
+    }
+
+    override fun beforeBodyWrite(
+        body: Any?,
+        returnType: MethodParameter,
+        selectedContentType: MediaType,
+        selectedConverterType: Class<out HttpMessageConverter<*>>,
+        request: ServerHttpRequest,
+        response: ServerHttpResponse
+    ): Any? {
+        logger.info { "Søknad $body" }
+        return body
+    }
+}

--- a/mottak/src/main/kotlin/no/nav/melosys/soknadmottak/soknad/SoknadService.kt
+++ b/mottak/src/main/kotlin/no/nav/melosys/soknadmottak/soknad/SoknadService.kt
@@ -19,7 +19,7 @@ class SoknadService @Autowired constructor(
     }
 
     fun hentSøknad(soknadID: String): Soknad {
-        logger.debug { "Henter søknad med ID $soknadID" }
+        logger.info { "Henter søknad med ID $soknadID" }
         return soknadRepository.findBySoknadID(UUID.fromString(soknadID))
             ?: throw IkkeFunnetException("Finner ikke søknad med ID $soknadID")
     }


### PR DESCRIPTION
Jeg prøvde å løse dette med en interceptor (`HandlerInterceptorAdapter`) på pathen til endepunktet, og det funka fint for statuskode, headere etc., men jeg fant ikke noen grei måte å hente ut body-en på, så jeg løste det på en litt annen måte. Dette blir forhåpentligvis ganske midlertidig uansett, siden det vil være sensitive opplysninger i prod.