### PR TITLE
Enable auto-merge for Dependabot patch PRs

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -24,9 +24,10 @@ jobs:
        java-version: '11.x'
     - name: Build and test
       run: mvn --settings .github/maven-settings.xml verify
-  automerge:
+  dependabot-automerge:
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
 
     permissions:
       pull-requests: write
@@ -36,9 +37,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ssh-key: "${{ secrets.COMMIT_KEY }}"    
-      - name: Dependabot automerge
-        uses: fastify/github-action-merge-dependabot@v3
+          ssh-key: "${{ secrets.COMMIT_KEY }}"
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          target: patch
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot patch PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Som beskrevet her: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request