### PR TITLE
5296 Mottakstidpunkt lik innsendingstidspunkt

### DIFF
--- a/mottak/src/main/kotlin/no/nav/melosys/soknadmottak/kafka/SoknadMottatt.kt
+++ b/mottak/src/main/kotlin/no/nav/melosys/soknadmottak/kafka/SoknadMottatt.kt
@@ -2,6 +2,7 @@ package no.nav.melosys.soknadmottak.kafka
 
 import no.nav.melosys.soknadmottak.common.DomainEvent
 import no.nav.melosys.soknadmottak.soknad.Soknad
+import java.time.ZoneId
 import java.time.ZonedDateTime
 
 data class SoknadMottatt(
@@ -11,7 +12,8 @@ data class SoknadMottatt(
     companion object {
         operator fun invoke(soknad: Soknad) =
             SoknadMottatt(
-                soknadID = soknad.soknadID.toString()
+                soknadID = soknad.soknadID.toString(),
+                occuredOn = ZonedDateTime.ofInstant(soknad.innsendtTidspunkt, ZoneId.systemDefault())
             )
     }
 }


### PR DESCRIPTION
En del av https://jira.adeo.no/browse/MELOSYS-5296

Mottakstidpunktet til journalføring av elektronisk søknad bør være tidspunktet søknaden har blitt sendt inn i Altinn.
Dette slik at mottakstidpunkt er for bruker og andre  uavhengig av løsningen mellom Altinn og Melosys (der søknaden teknisk kan være mottatt på et senere tidspunkt enn det ble sendt inn).

Ref. https://jira.adeo.no/browse/MELOSYS-4101