### PR TITLE
5874: Bytte ingress for dev-miljø

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -78,7 +78,7 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-fss
           RESOURCE: nais.yaml
-          VAR: ingress=https://melosys-soknad-mottak.dev.intern.nav.no,KAFKA_POOL=nav-dev
+          VAR: ingress=https://melosys-soknad-mottak.intern.dev.nav.no,KAFKA_POOL=nav-dev
       - name: Deploy til prod-fss
         if: github.event.inputs.environment == 'prod' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
         uses: nais/deploy/actions/deploy@v1


### PR DESCRIPTION
[MELOSYS-5874](https://jira.adeo.no/browse/MELOSYS-5874)

Vi har noen applikasjoner i dev-gcp med ingresser som skal slås av 2. mai. Sannsynlig kommer det også for fss etterhvert.

https://nav-it.slack.com/archives/C01DE3M9YBV/p1677747333208699