### PR TITLE
NOJIRA Slett flaky soknadMottattIncrement-test

### DIFF
--- a/mottak/src/test/kotlin/no/nav/melosys/soknadmottak/soknad/SoknadStatsCacheTest.kt
+++ b/mottak/src/test/kotlin/no/nav/melosys/soknadmottak/soknad/SoknadStatsCacheTest.kt
@@ -1,20 +1,13 @@
 package no.nav.melosys.soknadmottak.soknad
 
 import io.kotest.matchers.doubles.shouldBeExactly
-import io.micrometer.core.instrument.Metrics
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
-import no.nav.melosys.soknadmottak.config.MetrikkConfig
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
-// NB!
-// Litt ustabile tester på raskere PC-er. Kan være at det er for lite tid mellom oppdatering av cache og henting av data.
-// Kjører stabilt i Github Actions.
-// En mulig fiks kan være å bruke @Cacheable i stedet for å lage en egen cache-klasse.
 @ExtendWith(MockKExtension::class)
 internal class SoknadStatsCacheTest {
     @MockK
@@ -36,14 +29,5 @@ internal class SoknadStatsCacheTest {
             .shouldBeExactly(3.0)
         cache.hentSoknaderMedLevert(true)
             .shouldBeExactly(6.0)
-    }
-
-    @Test
-    internal fun soknadMottattIncrement() {
-        Metrics.addRegistry(SimpleMeterRegistry())
-        MetrikkConfig.Metrikker.søknadMottatt.count().shouldBeExactly(0.0)
-        MetrikkConfig.Metrikker.søknadMottatt.increment()
-        MetrikkConfig.Metrikker.søknadMottatt.increment()
-        MetrikkConfig.Metrikker.søknadMottatt.count().shouldBeExactly(2.0)
     }
 }


### PR DESCRIPTION
## Problem

Testen \`SoknadStatsCacheTest.soknadMottattIncrement\$mottak\` feiler sporadisk i CI med:

> \`3.0 is not equal to expected value 0.0\`

Senest blokkerte dette dependabot-PR #316. Kommentaren i filen hevdet at testen var stabil i Github Actions, men det holder ikke lenger stikk.

## Rotårsak

Testen bruker \`MetrikkConfig.Metrikker.søknadMottatt\`, som er en statisk \`Counter\` registrert på \`Metrics.globalRegistry\` — et singleton i JVM-en.

\`\`\`kotlin
object Metrikker {
    internal val søknadMottatt = Counter.builder(SOKNAD_MOTTATT)
        .register(Metrics.globalRegistry)  // ← global state
}
\`\`\`

Når JVM gjenbrukes mellom tester, beholder counteren sin tilstand. Da er \`count().shouldBeExactly(0.0)\` avhengig av testrekkefølgen, og feiler hvis noen annen test (eller forrige kjøring) har \`increment\`'et den først.

## Hvorfor slette?

Testen tester at \`Counter.increment()\` faktisk øker teller-verdien — det er Micrometer sin egen funksjonalitet, dekket av deres egne tester. Vi tester ingen av *vår* kode her. Kost (flakiness, CI-blokkering) > nytte.

\`antallSoknaderICache\` beholdes uendret — den bruker mocks riktig og er ikke berørt.

## Testplan

- [ ] CI passerer uten \`soknadMottattIncrement\`
- [ ] Dependabot-PRer som var blokkert av denne kan nå rebases